### PR TITLE
Remove the outdated comments for hirb

### DIFF
--- a/pryrc_rails
+++ b/pryrc_rails
@@ -2,6 +2,7 @@
 
 begin
   require 'hirb' # sudo gem install cldwalker-hirb --source http://gems.github.com
+  require 'hirb'
   require "hirb-unicode"
 rescue LoadError
 end


### PR DESCRIPTION
- cldwalker-hirb will conflict with ‘hirb’ and it cause `Hirb::View.view_or_page_output(value) || @old_print.call(output, value)` error
